### PR TITLE
BBDD es casesensitive, conversión a mayus de ECOEstatus

### DIFF
--- a/app/model/ECOE.py
+++ b/app/model/ECOE.py
@@ -37,9 +37,9 @@ class ChronoNotFound(PageNotFound):
 
 
 class ECOEstatus(str, Enum):
-    DRAFT = "draft"
-    PUBLISHED = "published"
-    ARCHIVED = "archived"
+    DRAFT = "DRAFT"
+    PUBLISHED = "PUBLISHED"
+    ARCHIVED = "ARCHIVED"
 
 
 class ECOE(db.Model):


### PR DESCRIPTION
La base de datos requiere que la cadena "status" de ECOE sea uno de los valores especificados, todos en mayúsculas. El error se ha solucionado pasando los valores del modelo del Enum ECOEStatus a mayúsculas.