### PR TITLE
Permiso de lectura otorgado 2 veces

### DIFF
--- a/app/api/station.py
+++ b/app/api/station.py
@@ -17,7 +17,7 @@
 from flask_login import current_user
 from flask_potion import fields, signals
 from flask_potion.routes import Relation
-from app.api.user import PermissionResource
+from app.api.user import PermissionResource, UserResource
 from app.model.Station import Station
 from app.model.User import PermissionType, RoleType
 from .ecoe import EcoeChildResource
@@ -93,12 +93,17 @@ def before_delete_station(sender, item):
     
 @signals.before_create.connect_via(PermissionResource)
 def on_before_create_permission(sender, item):
-    
     if item.name == 'evaluate' and item.object == 'stations':
         station = StationResource.manager.read(item.id_object)
-        sender.manager.create({
-             'user': item.user,
-             'id_object': station.id_ecoe,
-             'name': 'read',
-             'object': 'ecoes'})
+        has_read_permission = False
+        for permission in item.user.permissions:
+            if permission.id_object is station.id_ecoe and permission.name == 'read' and permission.object == 'ecoes':
+                has_read_permission = True
+        
+        if not has_read_permission:
+            sender.manager.create({
+                'user': item.user,
+                'id_object': station.id_ecoe,
+                'name': 'read',
+                'object': 'ecoes'})
 


### PR DESCRIPTION
Si a un evaluador se le da el permiso de evaluar una estación, implicitamente se le da el de lectura. Por ello, si se le da a evaluar más de una estación dará un error de que el permiso de lectura está duplicado