### PR TITLE
Cambiar reordenamiento de estaciones

### DIFF
--- a/app/api/question.py
+++ b/app/api/question.py
@@ -93,6 +93,8 @@ def before_create_question(sender, item):
 @signals.before_update.connect_via(QuestionResource)
 def before_update_question(sender, item, changes):
     if 'order' in changes.keys():
+        if item.order == changes['order']:
+            return
         questions = Question.query.filter(Question.id_station == item.id_station).order_by(Question.order).all()
         order_items(item, questions, changes['order'], 'add')
 

--- a/app/api/question.py
+++ b/app/api/question.py
@@ -85,6 +85,10 @@ def before_delete_block(sender, item):
         order_items(item, blocks, item.order, 'del')
         recalculate_question_order(item.id_station)
 
+@signals.before_create.connect_via(QuestionResource)
+def before_create_question(sender, item):
+    recalculate_question_order(item.station.id)
+
 @signals.before_update.connect_via(QuestionResource)
 def before_update_question(sender, item, changes):
     if 'order' in changes.keys():

--- a/app/api/question.py
+++ b/app/api/question.py
@@ -74,7 +74,11 @@ def before_update_block(sender, item, changes):
 
 @signals.before_delete.connect_via(BlockResource)
 def before_delete_block(sender, item):
-    Question.query.filter(Question.id_station == item.id).delete()
+    try:
+        db.session.query(Question).filter(Question.id_block == item.id).delete()
+        db.session.commit()
+    except:
+        db.session.rollback()
     blocks = Block.query.filter(Block.id_station == item.id_station).order_by(Block.order).all()
 
     if len(blocks) > 1:

--- a/app/api/question.py
+++ b/app/api/question.py
@@ -19,6 +19,7 @@ from flask_potion.routes import Relation
 from app.model.Question import Block, Question
 from app.api._mainresource import OpenECOEResource
 from app.shared import order_items, calculate_order
+from app.model import db
 
 station_permissions = {
             'read': 'read:station',
@@ -61,7 +62,7 @@ def recalculate_question_order(id_station):
     unordered_questions = []
     for block in blocks:
         questions_by_block = [question for question in Question.query.filter(Question.id_block == block.id).order_by(Question.order).all()]
-        unordered_questions.extend()
+        unordered_questions.extend(questions_by_block)
 
     calculate_order(unordered_questions)
 

--- a/app/api/question.py
+++ b/app/api/question.py
@@ -14,10 +14,11 @@
 #      You should have received a copy of the GNU General Public License
 #      along with openECOE-API.  If not, see <https://www.gnu.org/licenses/>.
 
-from flask_potion import fields
+from flask_potion import fields, signals
 from flask_potion.routes import Relation
 from app.model.Question import Block, Question
 from app.api._mainresource import OpenECOEResource
+from app.shared import order_items, calculate_order
 
 station_permissions = {
             'read': 'read:station',
@@ -54,3 +55,40 @@ class BlockResource(OpenECOEResource):
 
     class Schema:
         station = fields.ToOne('stations')
+
+def recalculate_question_order(id_station):
+    blocks = Block.query.filter(Block.id_station == id_station).order_by(Block.order).all()
+    unordered_questions = []
+    for block in blocks:
+        questions_by_block = [question for question in Question.query.filter(Question.id_block == block.id).order_by(Question.order).all()]
+        unordered_questions.extend()
+
+    calculate_order(unordered_questions)
+
+@signals.before_update.connect_via(BlockResource)
+def before_update_block(sender, item, changes):
+    if 'order' in changes.keys():
+        blocks = Block.query.filter(Block.id_station == item.id_station).order_by(Block.order).all()
+        order_items(item, blocks, changes['order'], 'add')
+        recalculate_question_order(item.id_station)
+
+@signals.before_delete.connect_via(BlockResource)
+def before_delete_block(sender, item):
+    Question.query.filter(Question.id_station == item.id).delete()
+    blocks = Block.query.filter(Block.id_station == item.id_station).order_by(Block.order).all()
+
+    if len(blocks) > 1:
+        order_items(item, blocks, item.order, 'del')
+        recalculate_question_order(item.id_station)
+
+@signals.before_update.connect_via(QuestionResource)
+def before_update_question(sender, item, changes):
+    if 'order' in changes.keys():
+        questions = Question.query.filter(Question.id_station == item.id_station).order_by(Question.order).all()
+        order_items(item, questions, changes['order'], 'add')
+
+@signals.before_delete.connect_via(QuestionResource)
+def before_delete_question(sender, item):
+    questions = Question.query.filter(Question.id_station == item.id_station).order_by(Question.order).all()
+    if len(questions) > 1:
+        order_items(item, questions, item.order, 'del')

--- a/app/api/station.py
+++ b/app/api/station.py
@@ -67,21 +67,6 @@ def check_parent_stations_order(station, order):
         return True
     return order > station.parent_station.order 
 
-def order_station(item, new_order, operation='add'):
-    stations_ecoe = len(item.ecoe.stations)
-    if item.order > stations_ecoe or item.order < 1:
-        item.order = stations_ecoe
-    else:
-        stations_ecoe = Station.query.filter(Station.id_ecoe == item.ecoe.id).order_by(Station.order).all()
-        station_idx = item.order - 1
-        if operation == 'add': 
-            stations_ecoe.insert(new_order - 1, stations_ecoe.pop(station_idx))
-        else: # operation is delete
-            stations_ecoe.pop(station_idx)
-
-        for idx, station in enumerate(stations_ecoe):
-            station.order = idx + 1
-
 @signals.before_update.connect_via(StationResource)
 def before_update_station(sender, item, changes):
     if 'order' in changes.keys():

--- a/app/shared/__init__.py
+++ b/app/shared/__init__.py
@@ -1,0 +1,17 @@
+#  Copyright (c) 2019 Miguel Hernandez University of Elche
+#  This file is part of openECOE-API.
+#
+#      openECOE-API is free software: you can redistribute it and/or modify
+#      it under the terms of the GNU General Public License as published by
+#      the Free Software Foundation, either version 3 of the License, or
+#      (at your option) any later version.
+#
+#      openECOE-API is distributed in the hope that it will be useful,
+#      but WITHOUT ANY WARRANTY; without even the implied warranty of
+#      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#      GNU General Public License for more details.
+#
+#      You should have received a copy of the GNU General Public License
+#      along with openECOE-API.  If not, see <https://www.gnu.org/licenses/>.
+
+from app.shared.utils import *

--- a/app/shared/utils.py
+++ b/app/shared/utils.py
@@ -14,7 +14,7 @@ def order_items(item, items, new_order, operation):
         else:
             items.pop(item_idx)
         
-        calculate_order(items)
+    calculate_order(items)
 
 def calculate_order(items):
     for idx, current_item in enumerate(items):

--- a/app/shared/utils.py
+++ b/app/shared/utils.py
@@ -1,0 +1,17 @@
+def order_items(item, items, new_order, operation):
+    # Posibles operaciones add y del (añadir y borrar)
+    # Los items del array tienen que tener la propiedad order
+    if item.order > len(items) or item.order < 1:
+        item.order = len(items)
+    else:
+        item_idx = item.order - 1
+        if operation == 'add':
+            items.insert(new_order - 1, items.pop(item_idx))
+        else:
+            items.pop(item_idx)
+        
+        calculate_order(items)
+
+def calculate_order(items):
+    for idx, current_item in enumerate(items):
+        current_item.order = idx + 1

--- a/app/shared/utils.py
+++ b/app/shared/utils.py
@@ -1,12 +1,16 @@
 def order_items(item, items, new_order, operation):
     # Posibles operaciones add y del (añadir y borrar)
     # Los items del array tienen que tener la propiedad order
-    if item.order > len(items) or item.order < 1:
-        item.order = len(items)
+    if new_order < 1:
+        item.order = 1
     else:
         item_idx = item.order - 1
         if operation == 'add':
-            items.insert(new_order - 1, items.pop(item_idx))
+            position = new_order - 1
+            if new_order > len(items):
+                position = len(items)
+                
+            items.insert(position, items.pop(item_idx))
         else:
             items.pop(item_idx)
         


### PR DESCRIPTION
Previamente se permitía poner estaciones padre despues de la subestación